### PR TITLE
add "start" as alternative to status "mark"

### DIFF
--- a/content/help.html
+++ b/content/help.html
@@ -149,7 +149,7 @@ If you just want to search messages that have attachment, use attachment:yes ins
 <b>is:replied</b> or <b>i:UnRead</b> or <b>status:Forwarded</b> or <b>status:F</b>
 </p>
 <p>This expression searches all messages in the current folder or view for status, The
-status can be one of Replied, Read, Marked, Forwarded, UnRead, New, ImapDeleted or Attachment.
+status can be one of Replied, Read, Marked/Star, Forwarded, UnRead, New, ImapDeleted or Attachment.
 </p></li><li><p>
 
 <b>before:2011/03/09 07:12:00</b> or <b>be:09 Mar 2011 05:00:00</b> or <b>after:Mar 10, 2011</b> or <b>af:(2011/03/01 -2011/03/09)</b>


### PR DESCRIPTION
Really small contribution, to enable one use to think about starred message with term "star" rather than "mark" to filter such messages.

cf #10 